### PR TITLE
Fix missing uuid import in models

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String, Float, Boolean, DateTime, Text, ForeignKe
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from datetime import datetime
+import uuid
 
 from app.db.session import Base
 


### PR DESCRIPTION
## Summary
- import `uuid` in `app/db/models.py` so placeholder tables can be instantiated without NameError

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6840d601eadc8325ade9dfce78749c0c